### PR TITLE
Update main.js g_aPages array

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -120,7 +120,10 @@ function _showMenu( bShow )
 }
 
 //var g_aPages = [ "/", "/getting-started.html", "/downloads.html", "/docs", "/contrib", "/news", "/about.html", "/legalese.html", "/docs/member-faq.html", "/coc.html" ];
-var g_aPages = [ "/", "/getting-started.html", "/downloads.html", "/docs", "/contrib", "/news", "/about.html", "/legalese.html", "/faq.html", "/coc.html" ];
+//var g_aPages = [ "/", "/getting-started.html", "/downloads.html", "/docs", "/contrib", "/news", "/about.html", "/legalese.html", "/faq.html", "/coc.html" ];
+var g_aPages = [ "/", "/getting-started.html", "/docs", "/contrib", "/community-meetings", "/news", "/about.html", "/legalese.html", "/faq.html", "/coc.html" ];
+//var g_aPages = [ "/", "/getting-started.html", "/docs", "https://github.com/tianocore/tianocore.github.io/wiki/Reporting-Issues", "/contrib", "https://github.com/tianocore/tianocore.github.io/wiki/Acknowledgements", "/community-meetings", "/news" ];
+
 
 function _getCurrentPage()
 {


### PR DESCRIPTION
Updated g_aPages array to match current site, so next/back arrows don't throw a 404 when looking for downloads.html.
I didn't include the navigation items that link directly to the github wiki as i felt it weird to suddenly jump to another site